### PR TITLE
Shuffle sync server list before using

### DIFF
--- a/src/client/sync-client.ts
+++ b/src/client/sync-client.ts
@@ -9,6 +9,7 @@ import {
 } from '../types/rest-types'
 import { apiRequest } from '../util/api-request'
 import { CommonOptions } from '../util/common'
+import { shuffle } from '../util/shuffle'
 import { makeInfoClient } from './info-client'
 
 export interface SyncClient {
@@ -27,9 +28,15 @@ export interface SyncClient {
 export function makeSyncClient(opts: CommonOptions = {}): SyncClient {
   const infoClient = makeInfoClient(opts)
 
+  // Returns the sync servers from the info client shuffled
+  async function shuffledSyncServers(): Promise<string[]> {
+    const { syncServers } = await infoClient.getEdgeServers()
+    return shuffle(syncServers)
+  }
+
   return {
     async createRepo(syncKey) {
-      const { syncServers } = await infoClient.getEdgeServers()
+      const syncServers = await shuffledSyncServers()
       let error: Error = new Error(
         `Failed to create repo ${syncKey}: empty sync server list`
       )
@@ -52,7 +59,7 @@ export function makeSyncClient(opts: CommonOptions = {}): SyncClient {
     },
 
     async readRepo(syncKey, lastHash) {
-      const { syncServers } = await infoClient.getEdgeServers()
+      const syncServers = await shuffledSyncServers()
       let error: Error = new Error(
         `Failed to read repo ${syncKey}: empty sync server list`
       )
@@ -75,7 +82,7 @@ export function makeSyncClient(opts: CommonOptions = {}): SyncClient {
     },
 
     async updateRepo(syncKey, lastHash, body) {
-      const { syncServers } = await infoClient.getEdgeServers()
+      const syncServers = await shuffledSyncServers()
       let error: Error = new Error(
         `Failed to update repo ${syncKey}: empty sync server list`
       )

--- a/src/util/shuffle.ts
+++ b/src/util/shuffle.ts
@@ -1,0 +1,7 @@
+export function shuffle<T>(array: T[]): T[] {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[array[i], array[j]] = [array[j], array[i]]
+  }
+  return array
+}


### PR DESCRIPTION
This randomizes the load distribution on the sync server list.